### PR TITLE
feat: agregar Turborepo como orquestador del monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,91 @@
+# .gitignore para el repo cliniccare-platform
+# Reglas adaptadas para Django (backend) + Next.js/Node (frontend) + pnpm/turborepo
+
+# --------------------
+# Python / Django
+# --------------------
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.egg-info/
+build/
+dist/
+.venv/
+venv/
+env/
+ENV/
+.env
+.env.*
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Django
+db.sqlite3
+media/
+staticfiles/
+*.log
+local_settings.py
+coverage/
+htmlcov/
+.pytest_cache/
+
+# Don't ignore migrations (they should be versioned)
+# **/migrations/*.py
+# ignore only migration caches
+**/migrations/__pycache__/
+
+# --------------------
+# Node / Frontend (Next.js, pnpm)
+# --------------------
+node_modules/
+frontend/node_modules/
+
+# Next.js build and output
+frontend/.next/
+frontend/out/
+frontend/.vercel/
+
+# pnpm and turborepo caches
+.pnpm-store/
+.turbo/
+.turbo-cache/
+
+# Logs
+npm-debug.log*
+pnpm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Do not ignore lockfiles (we keep pnpm-lock.yaml)
+# package-lock.json
+
+# --------------------
+# IDE / Editor
+# --------------------
+.vscode/
+.vs/
+.idea/
+.DS_Store
+Thumbs.db
+
+# OS temporary
+*.swp
+*~
+
+# --------------------
+# Build / artifacts
+# --------------------
+/dist/
+/build/
+*.tgz
+
+# Docker
+docker-compose.override.yml
+Dockerfile.dev
+
+# Other
+*.log
+
+# Carpeta .github (personal, no subir al repo)
+.github/

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,11 +2,14 @@ SECRET_KEY=your-secret-key-here
 DEBUG=True
 ALLOWED_HOSTS=localhost,127.0.0.1
 
-DB_ENGINE=django.db.backends.postgresql
-DB_NAME=cliniccare
-DB_USER=postgres
-DB_PASSWORD=password
-DB_HOST=localhost
-DB_PORT=5432
+# Base de datos
+# Por defecto usa SQLite (no necesitas configurar nada mas).
+# Para usar PostgreSQL, descomenta y ajusta las siguientes lineas:
+# DB_ENGINE=django.db.backends.postgresql
+# DB_NAME=cliniccare
+# DB_USER=postgres
+# DB_PASSWORD=password
+# DB_HOST=localhost
+# DB_PORT=5432
 
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8000

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+"""Django's command-line utility for administrative tasks."""
+import os
+import sys
+
+
+def main():
+    """Run administrative tasks."""
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings')
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        raise ImportError(
+            "Couldn't import Django. Are you sure it's installed and "
+            "available on your PYTHONPATH environment variable? Did you "
+            "forget to activate a virtual environment?"
+        ) from exc
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == '__main__':
+    main()

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "backend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "node ../scripts/venv-run.js manage.py runserver 0.0.0.0:8000",
+    "migrate": "node ../scripts/venv-run.js manage.py migrate",
+    "makemigrations": "node ../scripts/venv-run.js manage.py makemigrations",
+    "lint": "echo \"TODO: configurar ruff o flake8\""
+  }
+}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,9 @@
 Django==4.2.8
 djangorestframework==3.14.0
-djangorestframework-simplejwt==5.3.2
+djangorestframework-simplejwt==5.3.1
+django-cors-headers==4.3.1
 python-dotenv==1.0.0
-psycopg2-binary==2.9.9
+
+# PostgreSQL (solo si usas PostgreSQL en vez de SQLite)
+# Descomenta la siguiente linea si configuras DB_ENGINE=django.db.backends.postgresql
+# psycopg2-binary==2.9.9

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -50,16 +50,24 @@ TEMPLATES = [
     },
 ]
 
+# Base de datos: SQLite por defecto para desarrollo local.
+# Para usar PostgreSQL, define DB_ENGINE=django.db.backends.postgresql en tu .env
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql',
+        'ENGINE': os.getenv('DB_ENGINE', 'django.db.backends.sqlite3'),
+        'NAME': os.getenv('DB_NAME', BASE_DIR / 'backend' / 'db.sqlite3'),
+    }
+}
+
+# Si se usa PostgreSQL, agregar las credenciales necesarias
+if 'postgresql' in DATABASES['default']['ENGINE']:
+    DATABASES['default'].update({
         'NAME': os.getenv('DB_NAME', 'cliniccare'),
         'USER': os.getenv('DB_USER', 'postgres'),
         'PASSWORD': os.getenv('DB_PASSWORD', 'password'),
         'HOST': os.getenv('DB_HOST', 'localhost'),
         'PORT': os.getenv('DB_PORT', '5432'),
-    }
-}
+    })
 
 AUTH_PASSWORD_VALIDATORS = [
     {'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator'},

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,276 @@
+# Guia de configuracion local — cliniccare-platform
+
+Este documento explica paso a paso como clonar, instalar y ejecutar el proyecto completo (backend Django + frontend Next.js) usando Turborepo como orquestador desde la raiz.
+
+---
+
+## Requisitos previos
+
+Antes de comenzar, asegurate de tener instaladas las siguientes herramientas:
+
+| Herramienta | Version minima | Como verificar         | Como instalar                          |
+|-------------|---------------|------------------------|----------------------------------------|
+| Node.js     | 20 LTS        | `node -v`              | https://nodejs.org                     |
+| pnpm        | 9+            | `pnpm -v`              | `npm install -g pnpm`                  |
+| Python      | 3.10+         | `python --version`     | https://www.python.org/downloads       |
+| Git         | 2.30+         | `git --version`        | https://git-scm.com                    |
+
+PostgreSQL es opcional para desarrollo local. Por defecto el backend usa SQLite, que no requiere instalacion. Si necesitas PostgreSQL (para staging o produccion), consulta la seccion "Usar PostgreSQL en vez de SQLite" mas abajo.
+
+Nota: Todo el equipo debe usar pnpm como gestor de paquetes de Node. El proyecto tiene un lockfile de pnpm (`pnpm-lock.yaml`) y usar npm o yarn causaria inconsistencias.
+
+---
+
+## Primera vez (configuracion desde cero)
+
+### 1. Clonar el repositorio
+
+```bash
+git clone https://github.com/mdtec-code-dev/cliniccare-platform.git
+cd cliniccare-platform
+```
+
+### 2. Instalar dependencias de Node y Turborepo
+
+Desde la raiz del proyecto:
+
+```bash
+pnpm install
+```
+
+Esto instala Turborepo, las dependencias del frontend y el wrapper del backend de un solo golpe.
+
+### 3. Crear el entorno virtual de Python
+
+Desde la raiz del proyecto:
+
+```bash
+python -m venv .venv
+```
+
+### 4. Activar el entorno virtual
+
+En Windows (PowerShell):
+
+```powershell
+.venv\Scripts\Activate.ps1
+```
+
+En macOS / Linux:
+
+```bash
+source .venv/bin/activate
+```
+
+Veras que el prompt de tu terminal cambia a algo como `(.venv)`. Esto indica que el venv esta activo.
+
+### 5. Instalar dependencias de Python
+
+Con el entorno virtual activo:
+
+```bash
+pip install -r backend/requirements.txt
+```
+
+### 6. Configurar variables de entorno del backend
+
+```bash
+cp backend/.env.example backend/.env
+```
+
+En Windows (PowerShell):
+
+```powershell
+Copy-Item backend\.env.example backend\.env
+```
+
+Abre `backend/.env` y ajusta los valores si lo necesitas. Por defecto usa SQLite y no requiere cambios para empezar.
+
+### 7. Ejecutar migraciones de Django
+
+Con el entorno virtual activo:
+
+```bash
+pnpm migrate
+```
+
+O de forma directa:
+
+```bash
+cd backend
+python manage.py migrate
+```
+
+### 8. Arrancar el proyecto
+
+Asegurate de tener el entorno virtual activo y ejecuta desde la raiz:
+
+```bash
+pnpm dev
+```
+
+Esto arranca en paralelo:
+- Frontend (Next.js) en http://localhost:3000
+- Backend (Django) en http://localhost:8000
+
+---
+
+## Ya tengo el repo clonado (dia a dia)
+
+Cada vez que retomes el trabajo:
+
+```bash
+# 1. Traer ultimos cambios
+git pull
+
+# 2. Activar el entorno virtual (si no lo esta)
+# Windows (PowerShell):
+.venv\Scripts\Activate.ps1
+# macOS / Linux:
+source .venv/bin/activate
+
+# 3. Actualizar dependencias (por si cambiaron)
+pnpm install
+pip install -r backend/requirements.txt
+
+# 4. Ejecutar migraciones pendientes (por si hay nuevas)
+pnpm migrate
+
+# 5. Arrancar todo
+pnpm dev
+```
+
+---
+
+## Comandos disponibles
+
+Todos estos comandos se ejecutan desde la raiz del proyecto.
+
+| Comando                | Que hace                                           |
+|-----------------------|----------------------------------------------------|
+| `pnpm dev`            | Arranca frontend + backend en paralelo             |
+| `pnpm dev:frontend`   | Solo Next.js en http://localhost:3000               |
+| `pnpm dev:backend`    | Solo Django en http://localhost:8000                |
+| `pnpm build`          | Build de produccion del frontend                   |
+| `pnpm lint`           | Ejecuta lint en todos los workspaces               |
+| `pnpm migrate`        | Ejecuta migraciones de Django                      |
+| `pnpm makemigrations` | Genera nuevas migraciones de Django                |
+
+---
+
+## Activar y desactivar el entorno virtual
+
+El entorno virtual de Python es necesario siempre que trabajes con el backend o ejecutes `pnpm dev` (porque Turborepo invoca `python` y espera que este en el PATH del venv).
+
+Activar:
+
+```powershell
+# Windows (PowerShell)
+.venv\Scripts\Activate.ps1
+
+# macOS / Linux
+source .venv/bin/activate
+```
+
+Desactivar:
+
+```bash
+deactivate
+```
+
+---
+
+## Solucion de problemas comunes
+
+### "python no se reconoce como comando"
+
+Asegurate de que Python esta en tu PATH del sistema. En Windows, al instalar Python marca la casilla "Add Python to PATH".
+
+### "pnpm: command not found"
+
+Instala pnpm globalmente:
+
+```bash
+npm install -g pnpm
+```
+
+### Error de conexion a PostgreSQL
+
+Verifica que PostgreSQL esta corriendo y que los datos en `backend/.env` son correctos. Puedes probar la conexion con:
+
+```bash
+psql -h localhost -U postgres -d cliniccare
+```
+
+### Las migraciones fallan
+
+Si cambiaste de rama y hay migraciones nuevas, ejecuta:
+
+```bash
+pnpm migrate
+```
+
+Si hay conflictos de migraciones, consulta con el equipo antes de hacer merge manual.
+
+### El frontend no arranca o muestra errores de dependencias
+
+Borra la cache y reinstala:
+
+```bash
+rm -rf node_modules frontend/node_modules frontend/.next
+pnpm install
+```
+
+En Windows (PowerShell):
+
+```powershell
+Remove-Item -Recurse -Force node_modules, frontend\node_modules, frontend\.next
+pnpm install
+```
+
+---
+
+## Usar PostgreSQL en vez de SQLite (opcional)
+
+Por defecto el backend usa SQLite para simplificar el desarrollo local. Si necesitas PostgreSQL (por ejemplo para staging, produccion, o para probar queries especificas de Postgres):
+
+### 1. Instalar PostgreSQL
+
+Descarga e instala desde https://www.postgresql.org/download. Verifica con:
+
+```bash
+psql --version
+```
+
+### 2. Instalar el driver de Python
+
+Con el entorno virtual activo:
+
+```bash
+pip install psycopg2-binary==2.9.9
+```
+
+### 3. Crear la base de datos
+
+```sql
+CREATE DATABASE cliniccare;
+```
+
+### 4. Configurar las variables de entorno
+
+Edita `backend/.env` y descomenta/ajusta las lineas de PostgreSQL:
+
+```
+DB_ENGINE=django.db.backends.postgresql
+DB_NAME=cliniccare
+DB_USER=postgres
+DB_PASSWORD=tu_password
+DB_HOST=localhost
+DB_PORT=5432
+```
+
+### 5. Ejecutar migraciones
+
+```bash
+pnpm migrate
+```

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,3 +1,0 @@
-ignoredBuiltDependencies:
-  - sharp
-  - unrs-resolver

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cliniccare-platform",
+  "version": "0.1.0",
+  "private": true,
+  "packageManager": "pnpm@9.15.4",
+  "scripts": {
+    "dev": "node scripts/kill-ports.js && turbo run dev",
+    "dev:frontend": "node scripts/kill-ports.js && turbo run dev --filter=frontend",
+    "dev:backend": "node scripts/kill-ports.js && turbo run dev --filter=backend",
+    "build": "turbo run build",
+    "lint": "turbo run lint",
+    "stop": "node scripts/kill-ports.js",
+    "migrate": "node scripts/venv-run.js manage.py migrate",
+    "makemigrations": "node scripts/venv-run.js manage.py makemigrations"
+  },
+  "devDependencies": {
+    "turbo": "^2"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,14 @@ settings:
 importers:
 
   .:
+    devDependencies:
+      turbo:
+        specifier: ^2
+        version: 2.8.3
+
+  backend: {}
+
+  frontend:
     dependencies:
       next:
         specifier: 16.1.6
@@ -209,105 +217,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -374,28 +366,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.6':
     resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.6':
     resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.6':
     resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.6':
     resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
@@ -469,28 +457,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -644,49 +628,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -821,8 +797,8 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  caniuse-lite@1.0.30001768:
-    resolution: {integrity: sha512-qY3aDRZC5nWPgHUgIB84WL+nySuo19wk0VJpp/XI9T34lrvkyhRvNVOFJOp2kxClQhiFBu+TaUSudf6oa3vkSA==}
+  caniuse-lite@1.0.30001769:
+    resolution: {integrity: sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1150,8 +1126,8 @@ packages:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
 
-  get-tsconfig@4.13.3:
-    resolution: {integrity: sha512-vp8Cj/+9Q/ibZUrq1rhy8mCTQpCk31A3uu9wc1C50yAb3x2pFHOsGdAZQ7jD86ARayyxZUViYeIztW+GE8dcrg==}
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1433,28 +1409,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -1847,6 +1819,40 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  turbo-darwin-64@2.8.3:
+    resolution: {integrity: sha512-4kXRLfcygLOeNcP6JquqRLmGB/ATjjfehiojL2dJkL7GFm3SPSXbq7oNj8UbD8XriYQ5hPaSuz59iF1ijPHkTw==}
+    cpu: [x64]
+    os: [darwin]
+
+  turbo-darwin-arm64@2.8.3:
+    resolution: {integrity: sha512-xF7uCeC0UY0Hrv/tqax0BMbFlVP1J/aRyeGQPZT4NjvIPj8gSPDgFhfkfz06DhUwDg5NgMo04uiSkAWE8WB/QQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  turbo-linux-64@2.8.3:
+    resolution: {integrity: sha512-vxMDXwaOjweW/4etY7BxrXCSkvtwh0PbwVafyfT1Ww659SedUxd5rM3V2ZCmbwG8NiCfY7d6VtxyHx3Wh1GoZA==}
+    cpu: [x64]
+    os: [linux]
+
+  turbo-linux-arm64@2.8.3:
+    resolution: {integrity: sha512-mQX7uYBZFkuPLLlKaNe9IjR1JIef4YvY8f21xFocvttXvdPebnq3PK1Zjzl9A1zun2BEuWNUwQIL8lgvN9Pm3Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  turbo-windows-64@2.8.3:
+    resolution: {integrity: sha512-YLGEfppGxZj3VWcNOVa08h6ISsVKiG85aCAWosOKNUjb6yErWEuydv6/qImRJUI+tDLvDvW7BxopAkujRnWCrw==}
+    cpu: [x64]
+    os: [win32]
+
+  turbo-windows-arm64@2.8.3:
+    resolution: {integrity: sha512-afTUGKBRmOJU1smQSBnFGcbq0iabAPwh1uXu2BVk7BREg30/1gMnJh9DFEQTah+UD3n3ru8V55J83RQNFfqoyw==}
+    cpu: [arm64]
+    os: [win32]
+
+  turbo@2.8.3:
+    resolution: {integrity: sha512-8Osxz5Tu/Dw2kb31EAY+nhq/YZ3wzmQSmYa1nIArqxgCAldxv9TPlrAiaBUDVnKA4aiPn0OFBD1ACcpc5VFOAQ==}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2652,7 +2658,7 @@ snapshots:
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.9.19
-      caniuse-lite: 1.0.30001768
+      caniuse-lite: 1.0.30001769
       electron-to-chromium: 1.5.286
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
@@ -2676,7 +2682,7 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  caniuse-lite@1.0.30001768: {}
+  caniuse-lite@1.0.30001769: {}
 
   chalk@4.1.2:
     dependencies:
@@ -2904,7 +2910,7 @@ snapshots:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
       eslint: 9.39.2(jiti@2.6.1)
-      get-tsconfig: 4.13.3
+      get-tsconfig: 4.13.6
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
       tinyglobby: 0.2.15
@@ -3161,7 +3167,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
 
-  get-tsconfig@4.13.3:
+  get-tsconfig@4.13.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
@@ -3499,7 +3505,7 @@ snapshots:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.9.19
-      caniuse-lite: 1.0.30001768
+      caniuse-lite: 1.0.30001769
       postcss: 8.4.31
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
@@ -3892,6 +3898,33 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  turbo-darwin-64@2.8.3:
+    optional: true
+
+  turbo-darwin-arm64@2.8.3:
+    optional: true
+
+  turbo-linux-64@2.8.3:
+    optional: true
+
+  turbo-linux-arm64@2.8.3:
+    optional: true
+
+  turbo-windows-64@2.8.3:
+    optional: true
+
+  turbo-windows-arm64@2.8.3:
+    optional: true
+
+  turbo@2.8.3:
+    optionalDependencies:
+      turbo-darwin-64: 2.8.3
+      turbo-darwin-arm64: 2.8.3
+      turbo-linux-64: 2.8.3
+      turbo-linux-arm64: 2.8.3
+      turbo-windows-64: 2.8.3
+      turbo-windows-arm64: 2.8.3
 
   type-check@0.4.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "frontend"
+  - "backend"

--- a/scripts/kill-ports.js
+++ b/scripts/kill-ports.js
@@ -1,0 +1,51 @@
+const { execSync } = require('child_process');
+const os = require('os');
+
+// Mata procesos huerfanos de Next.js (node) y Django (python runserver)
+// que pueden quedar vivos despues de cancelar pnpm dev / turbo
+
+const isWin = os.platform() === 'win32';
+
+function kill(processName, port) {
+  try {
+    if (isWin) {
+      // Matar por puerto
+      const netstat = execSync(`netstat -ano | findstr :${port} | findstr LISTENING`, { encoding: 'utf-8' });
+      const lines = netstat.trim().split('\n');
+      const pids = new Set();
+      for (const line of lines) {
+        const parts = line.trim().split(/\s+/);
+        const pid = parts[parts.length - 1];
+        if (pid && pid !== '0') pids.add(pid);
+      }
+      for (const pid of pids) {
+        try {
+          execSync(`taskkill /PID ${pid} /F`, { stdio: 'inherit' });
+          console.log(`Proceso ${processName} (PID ${pid}, puerto ${port}) terminado.`);
+        } catch (_) {
+          // ya murio
+        }
+      }
+    } else {
+      // Unix: matar por puerto con lsof
+      const lsof = execSync(`lsof -ti :${port}`, { encoding: 'utf-8' });
+      const pids = lsof.trim().split('\n').filter(Boolean);
+      for (const pid of pids) {
+        try {
+          execSync(`kill -9 ${pid}`, { stdio: 'inherit' });
+          console.log(`Proceso ${processName} (PID ${pid}, puerto ${port}) terminado.`);
+        } catch (_) {
+          // ya murio
+        }
+      }
+    }
+  } catch (_) {
+    console.log(`No se encontraron procesos de ${processName} en puerto ${port}.`);
+  }
+}
+
+console.log('Buscando procesos huerfanos...\n');
+kill('Next.js (frontend)', 3000);
+kill('Next.js (frontend)', 3001);
+kill('Django (backend)', 8000);
+console.log('\nListo.');

--- a/scripts/venv-run.js
+++ b/scripts/venv-run.js
@@ -1,0 +1,31 @@
+const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+// Resolver la ruta del Python del venv desde la raiz del monorepo
+const root = path.resolve(__dirname, '..');
+const venvWin = path.join(root, '.venv', 'Scripts', 'python.exe');
+const venvUnix = path.join(root, '.venv', 'bin', 'python');
+
+let pythonPath;
+
+if (fs.existsSync(venvWin)) {
+  pythonPath = venvWin;
+} else if (fs.existsSync(venvUnix)) {
+  pythonPath = venvUnix;
+} else {
+  console.error('ERROR: No se encontro el entorno virtual (.venv).');
+  console.error('Crea el venv con: python -m venv .venv');
+  console.error('Luego instala dependencias: pip install -r backend/requirements.txt');
+  process.exit(1);
+}
+
+// Los argumentos despues de "node scripts/venv-run.js" se pasan a python
+const args = process.argv.slice(2).join(' ');
+const cmd = `"${pythonPath}" ${args}`;
+
+try {
+  execSync(cmd, { stdio: 'inherit', cwd: path.join(root, 'backend') });
+} catch (e) {
+  process.exit(e.status || 1);
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "build": {
+      "outputs": [".next/**", "!.next/cache/**"]
+    },
+    "lint": {}
+  }
+}


### PR DESCRIPTION
## Descripcion
Integra Turborepo para orquestar frontend (Next.js) y backend (Django) 
desde la raiz del monorepo con un solo comando.

## Cambios
- turbo.json, pnpm-workspace.yaml y package.json en la raiz
- backend/package.json wrapper para scripts Django via Turbo
- scripts/venv-run.js (resuelve Python del venv cross-platform)
- scripts/kill-ports.js (limpia procesos huerfanos al iniciar dev)
- .gitignore con reglas para Django, Next.js, pnpm y Turbo
- docs/setup.md guia de onboarding
- backend/requirements.txt (agregar django-cors-headers, corregir simplejwt)
- backend/settings.py usa SQLite por defecto en desarrollo local
- backend/.env.example (PostgreSQL comentado por defecto)

## Comandos disponibles
- `pnpm dev` — frontend + backend en paralelo
- `pnpm dev:frontend` / `pnpm dev:backend` — individual
- `pnpm stop` — mata procesos huerfanos

## Nota
Closes #4

El backend no arranca por un error de configuracion de Django 
(label duplicado "auth"). Ver issue referenciado.